### PR TITLE
Camera stop all

### DIFF
--- a/js/WebCodeCam.js
+++ b/js/WebCodeCam.js
@@ -21,6 +21,7 @@ qr-decoder (qrcodelib.js) -> https://github.com/LazarSoft/jsqrcode
     var w, h;
     var DecodeWorker = new Worker("js/DecoderWorker.js");
     var delay = false;
+    var streams = [];
     var pluginName = "WebCodeCam",
         defaults = {
             ReadQRCode: true,
@@ -86,7 +87,7 @@ qr-decoder (qrcodelib.js) -> https://github.com/LazarSoft/jsqrcode
         cameraSuccess: function(stream) {
             var url = window.URL || window.webkitURL;
             camera.src = url ? url.createObjectURL(stream) : stream;
-            $().WebCodeCam.stream = stream;
+            streams.push(stream);
             camera.play();
         },
         cameraError: function(error) {
@@ -204,7 +205,10 @@ qr-decoder (qrcodelib.js) -> https://github.com/LazarSoft/jsqrcode
         cameraStopAll: function () {
             delay = true;
             camera.pause();
-            $().WebCodeCam.stream.stop();
+            for(var i = 0; i < streams.length; i++) {
+                streams[i].stop();
+            }
+            streams.splice(0);
         },
         cameraPlay: function() {
             delay = true;

--- a/js/WebCodeCam.js
+++ b/js/WebCodeCam.js
@@ -86,6 +86,7 @@ qr-decoder (qrcodelib.js) -> https://github.com/LazarSoft/jsqrcode
         cameraSuccess: function(stream) {
             var url = window.URL || window.webkitURL;
             camera.src = url ? url.createObjectURL(stream) : stream;
+            $().WebCodeCam.stream = stream;
             camera.play();
         },
         cameraError: function(error) {
@@ -199,6 +200,11 @@ qr-decoder (qrcodelib.js) -> https://github.com/LazarSoft/jsqrcode
         cameraStop: function() {
             delay = true;
             camera.pause();
+        },
+        cameraStopAll: function () {
+            delay = true;
+            camera.pause();
+            $().WebCodeCam.stream.stop();
         },
         cameraPlay: function() {
             delay = true;


### PR DESCRIPTION
Added cameraStopAll function to stop all getUserMedia streams that are active. Differs to cameraStop as that only pauses the video, doesn't stop the stream